### PR TITLE
feat(ui): redesign site with Swiss × Bauhaus × Riso theme

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,5 @@
 <footer class="site-footer">
   <div class="wrap foot-in">
-    <span class="foot-brand">{{ site.author.name }}</span>
     <div class="foot-links">
       <a href="https://github.com/{{ site.author.github }}">GitHub</a>
       {% if site.author.linkedin != "" %}<a href="https://www.linkedin.com/in/{{ site.author.linkedin }}">LinkedIn</a>{% endif %}
@@ -8,5 +7,5 @@
       <a href="{{ '/feed.xml' | relative_url }}">RSS</a>
     </div>
   </div>
-  <div class="wrap foot-copy">© {{ site.time | date: '%Y' }} {{ site.author.name }}</div>
+  <div class="wrap foot-copy">© {{ site.time | date: '%Y' }}</div>
 </footer>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,9 +2,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,600&family=JetBrains+Mono:wght@400;500&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&family=Archivo:wght@400;500;600;700&family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,600&family=JetBrains+Mono:wght@400;500&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
 <link rel="icon" href="{{ '/assets/images/logo.png' | relative_url }}">
-<script>(function(){var t=localStorage.getItem('theme');if(!t){t=matchMedia('(prefers-color-scheme: light)').matches?'light':'dark';}document.documentElement.setAttribute('data-theme',t);})();</script>
+<script>(function(){var t=localStorage.getItem('theme')||'light';document.documentElement.setAttribute('data-theme',t);})();</script>
 {% include seo.html %}
 {% feed_meta %}

--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -1,12 +1,18 @@
 <header class="hero">
-  <div class="wrap">
-    <div class="hero-glow" aria-hidden="true"></div>
-    <p class="mono kicker">{{ site.author.role }}</p>
-    <h1 class="hero-h">Code &amp; kilometers.<br><span class="accent">{{ site.tagline }}</span></h1>
-    <p class="hero-sub">Hi, I'm Akhilesh, a data scientist who likes automation, coding, and building things on the side.</p>
-    <div class="hero-btns">
-      <a href="{{ '/writing/' | relative_url }}" class="btn btn-primary">Read the blog</a>
-      <a href="{{ '/projects/' | relative_url }}" class="btn btn-ghost">See projects</a>
+  <div class="wrap hero-grid">
+    <div class="hero-main">
+      <p class="mono kicker">{{ site.author.role }}</p>
+      <h1 class="hero-h">Code &amp; kilometers.<br><span class="accent">{{ site.tagline }}</span></h1>
+      <p class="hero-sub">Hi, I'm Akhilesh, a data scientist who likes automation, coding, and building things on the side.</p>
+      <div class="hero-btns">
+        <a href="{{ '/writing/' | relative_url }}" class="btn btn-primary">Read the blog</a>
+        <a href="{{ '/projects/' | relative_url }}" class="btn btn-ghost">See projects</a>
+      </div>
+    </div>
+    <div class="hero-fig" aria-hidden="true">
+      <span class="fig-c-y"></span>
+      <span class="fig-tri"></span>
+      <span class="fig-c-b"></span>
     </div>
   </div>
 </header>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -2,7 +2,7 @@
   <div class="wrap nav-in">
     <a class="brand" href="{{ '/' | relative_url }}">
       <img class="brand-logo" src="{{ '/assets/images/logo.png' | relative_url }}" alt="">
-      <span>~/akhilesh</span>
+      <span>{{ site.author.name }}</span>
     </a>
     <button id="nav-toggle" class="nav-toggle" type="button" aria-label="Menu" aria-expanded="false">
       <span></span><span></span><span></span>

--- a/_includes/section-now.html
+++ b/_includes/section-now.html
@@ -1,7 +1,7 @@
 <section class="wrap section">
   {% assign now = site.now %}
   <div class="about">
-    <blockquote>I like <span class="accent">data, automation, and coding</span>, and I build things on the side. This is where I share what I make and learn.</blockquote>
+    <blockquote class="lead">I like <span class="accent">data, automation, and coding</span>, and I build things on the side. This is where I share what I make and learn.</blockquote>
     <div class="now-card">
       <h4>// Now</h4>
       {% if now.size > 0 %}

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -2,11 +2,21 @@
 html{scroll-behavior:smooth}
 body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--body);
   line-height:1.6;-webkit-font-smoothing:antialiased}
+/* Riso grain — a subtle fixed print texture over the whole page */
+body::before{content:"";position:fixed;inset:0;z-index:1;pointer-events:none;opacity:.22;
+  mix-blend-mode:var(--blend);
+  background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='120' height='120'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix type='saturate' values='0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)' opacity='0.3'/></svg>")}
 a{color:inherit;text-decoration:none}
 img{max-width:100%;display:block}
 h1,h2,h3{letter-spacing:-.01em}
-main{display:block}
+main{display:block;position:relative;z-index:2}
 @media (prefers-reduced-motion: reduce){
   *{animation:none!important;transition:none!important;scroll-behavior:auto!important}
 }
 :focus-visible{outline:2px solid var(--accent);outline-offset:3px}
+
+/* Bauhaus primary-shape helpers (used by hero, cards, lists) */
+.geo{display:inline-block;flex:none}
+.geo--circle{border-radius:50%}
+.geo--tri{width:0;height:0;background:none!important;
+  border-left:.5em solid transparent;border-right:.5em solid transparent;border-bottom:1em solid currentColor}

--- a/_sass/cards.scss
+++ b/_sass/cards.scss
@@ -1,55 +1,78 @@
-/* Facets */
-.facets{display:grid;gap:16px;grid-template-columns:1fr}
+/* Facets — Swiss bordered cells */
+.facets{display:grid;gap:0;grid-template-columns:1fr;border:1px solid var(--line2)}
 @media(min-width:800px){.facets{grid-template-columns:repeat(3,1fr)}}
-.facet{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:26px 22px;
-  transition:transform .15s,border-color .15s;display:block}
-.facet:hover{transform:translateY(-4px);border-color:rgba(192,132,252,.45)}
-.facet .ic{font-size:1.4rem;margin-bottom:14px}
-.facet h3{font-family:var(--disp);font-size:1.15rem;margin:0 0 8px}
-.facet p{color:var(--muted);font-size:.92rem;margin:0}
-.facet .lk{display:inline-block;margin-top:14px;font-family:var(--mono);font-size:.72rem;color:var(--accent)}
+.facet{background:var(--card);border-bottom:1px solid var(--line2);padding:28px 24px;
+  transition:background .18s;display:block}
+@media(min-width:800px){.facet{border-bottom:0;border-right:1px solid var(--line2)}
+  .facet:last-child{border-right:0}}
+.facet:hover{background:var(--bg2)}
+.facet .ic{font-size:1.4rem;margin-bottom:16px}
+.facet h3{font-family:var(--disp);font-weight:600;font-size:1.1rem;margin:0 0 8px;letter-spacing:-.01em}
+.facet p{color:var(--muted);font-size:.9rem;margin:0}
+.facet .lk{display:inline-block;margin-top:16px;font-family:var(--mono);font-size:.68rem;
+  letter-spacing:.1em;text-transform:uppercase;color:var(--red)}
 
-/* Writing list */
+/* Writing list — hairline editorial rows */
 .posts{display:flex;flex-direction:column}
-.post{display:grid;grid-template-columns:88px 1fr;gap:22px;padding:20px 0;
-  border-bottom:1px solid var(--line);align-items:baseline}
-.post:hover h3{color:var(--accent)}
-.post .date{font-family:var(--mono);font-size:.72rem;color:var(--muted);padding-top:4px}
-.post h3{font-family:var(--serif);font-weight:600;font-size:1.3rem;margin:0 0 6px;transition:color .15s}
-.post p{color:var(--muted);font-size:.92rem;margin:0}
-.tag{font-family:var(--mono);font-size:.66rem;color:var(--amber);margin-right:10px}
+.post{display:grid;grid-template-columns:96px 1fr;gap:24px;padding:22px 0;
+  border-top:1px solid var(--line);align-items:baseline;transition:padding-left .18s}
+.post:first-child{border-top:0}
+.post:hover{padding-left:12px}
+.post:hover h3{color:var(--red)}
+.post .date{font-family:var(--mono);font-size:.7rem;letter-spacing:.06em;color:var(--muted);padding-top:5px}
+.post h3{font-family:var(--disp);font-weight:500;font-size:clamp(1.15rem,2.3vw,1.5rem);
+  margin:0 0 6px;letter-spacing:-.01em;transition:color .15s}
+.post p{color:var(--muted);font-size:.9rem;margin:0}
+.tag{font-family:var(--mono);font-size:.64rem;letter-spacing:.06em;color:var(--blue);margin-right:10px}
 
-/* Projects */
-.projects{display:grid;gap:16px;grid-template-columns:1fr}
+/* Projects — bordered cards with Bauhaus primary badges */
+.projects{display:grid;gap:0;grid-template-columns:1fr;border:1px solid var(--line2)}
 @media(min-width:800px){.projects{grid-template-columns:1fr 1fr}}
-.proj{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:24px;
-  transition:transform .15s,border-color .15s;display:block}
-.proj:hover{transform:translateY(-4px);border-color:rgba(245,184,65,.45)}
-.proj h3{font-family:var(--disp);font-size:1.2rem;margin:0 0 8px}
-.proj p{color:var(--muted);font-size:.9rem;margin:0 0 14px}
+.proj{background:var(--card);border-bottom:1px solid var(--line2);padding:26px 24px;
+  transition:background .18s;display:flex;flex-direction:column;min-height:200px}
+@media(min-width:800px){.proj{border-right:1px solid var(--line2)}
+  .proj:nth-child(2n){border-right:0}}
+.proj:hover{background:var(--bg2)}
+.proj::before{content:"";width:26px;height:26px;margin-bottom:auto;display:block}
+.proj:nth-child(3n+1)::before{background:var(--red);border-radius:50%}
+.proj:nth-child(3n+2)::before{background:var(--yellow)}
+.proj:nth-child(3n+3)::before{width:0;height:0;background:none;
+  border-left:13px solid transparent;border-right:13px solid transparent;border-bottom:26px solid var(--blue)}
+.proj h3{font-family:var(--disp);font-weight:600;font-size:1.2rem;margin:22px 0 8px;letter-spacing:-.01em}
+.proj p{color:var(--muted);font-size:.9rem;margin:0 0 16px;flex:1}
 .stack{display:flex;gap:8px;flex-wrap:wrap}
-.pill{font-family:var(--mono);font-size:.66rem;color:var(--muted);border:1px solid var(--line);
-  padding:3px 9px;border-radius:6px}
+.pill{font-family:var(--mono);font-size:.64rem;letter-spacing:.06em;color:var(--muted);
+  border:1px solid var(--line2);padding:3px 9px}
 
-/* Making gallery */
-.gallery{display:grid;gap:12px;grid-template-columns:repeat(2,1fr)}
+/* Making gallery — Swiss bordered tiles */
+.gallery{display:grid;gap:var(--gap);grid-template-columns:repeat(2,1fr)}
 @media(min-width:800px){.gallery{grid-template-columns:repeat(4,1fr)}}
 .gallery-index{grid-template-columns:repeat(2,1fr)}
 @media(min-width:800px){.gallery-index{grid-template-columns:repeat(3,1fr)}}
-.shot{aspect-ratio:1;border-radius:12px;border:1px solid var(--line);display:flex;
-  align-items:flex-end;padding:12px;background:var(--card);transition:transform .15s}
-.shot:hover{transform:translateY(-4px)}
-.shot span{font-family:var(--mono);font-size:.68rem;color:var(--ink);font-weight:500}
+.shot{aspect-ratio:1;border:1px solid var(--line2);display:flex;
+  align-items:flex-end;padding:12px;background:var(--card);transition:border-color .18s}
+.shot:hover{border-color:var(--ink)}
+.shot span{font-family:var(--mono);font-size:.66rem;letter-spacing:.06em;text-transform:uppercase;
+  color:var(--ink);font-weight:500}
 
 /* About + Now */
-.about{display:grid;gap:32px;grid-template-columns:1fr}
-@media(min-width:800px){.about{grid-template-columns:1.4fr 1fr}}
+.about{display:grid;gap:0;grid-template-columns:1fr}
+@media(min-width:800px){.about{grid-template-columns:1.5fr 1fr;gap:40px}}
 .about--solo{grid-template-columns:1fr!important}
 .about--solo blockquote{max-width:26ch}
-.about blockquote{font-family:var(--serif);font-size:1.45rem;line-height:1.5;margin:0;color:#DCDAD3}
-.about blockquote .accent{color:var(--accent)}
-.now-card{background:var(--bg2);border:1px solid var(--line);border-radius:14px;padding:22px}
-.now-card h4{font-family:var(--mono);font-size:.72rem;color:var(--amber);text-transform:uppercase;
-  letter-spacing:.08em;margin:0 0 12px}
-.now-card ul{margin:0;padding-left:18px;color:var(--muted);font-size:.92rem;line-height:1.9}
+.about .lead{padding-right:0}
+@media(min-width:800px){.about .lead{padding-right:40px;border-right:1px solid var(--line)}}
+.about blockquote{font-family:var(--disp);font-weight:400;font-size:clamp(1.4rem,3vw,2rem);
+  line-height:1.28;margin:0;letter-spacing:-.01em}
+.about blockquote .accent{color:var(--red);font-weight:500}
+.now-card{padding:0}
+@media(max-width:800px){.now-card{margin-top:32px}}
+.now-card h4{font-family:var(--mono);font-size:.7rem;color:var(--muted);text-transform:uppercase;
+  letter-spacing:.16em;margin:0 0 16px}
+.now-card ul{margin:0;padding:0;list-style:none;color:var(--ink);font-size:.95rem}
+.now-card li{padding:12px 0;border-top:1px solid var(--line);display:flex;gap:12px;line-height:1.45}
+.now-card li::before{content:"";width:8px;height:8px;margin-top:7px;flex:none;background:var(--red)}
+.now-card li:nth-child(2)::before{background:var(--blue);border-radius:50%}
+.now-card li:nth-child(3)::before{width:0;height:0;background:none;
+  border-left:5px solid transparent;border-right:5px solid transparent;border-bottom:9px solid var(--yellow)}
 .now-empty{margin:0;color:var(--muted);font-size:.92rem;font-style:italic}

--- a/_sass/footer.scss
+++ b/_sass/footer.scss
@@ -1,6 +1,8 @@
-.site-footer{border-top:1px solid var(--line);padding:48px 0 60px;margin-top:64px}
+.site-footer{border-top:1px solid var(--line);padding:40px 0 56px;margin-top:0;position:relative;z-index:2}
 .foot-in{display:flex;justify-content:space-between;gap:24px;flex-wrap:wrap;align-items:center}
-.foot-brand{font-family:var(--disp);font-weight:700;font-size:1.2rem}
-.foot-links{display:flex;gap:20px;font-family:var(--mono);font-size:.78rem;color:var(--muted)}
-.foot-links a:hover{color:var(--accent)}
-.foot-copy{margin-top:18px;font-family:var(--mono);font-size:.7rem;color:var(--muted);opacity:.7}
+.foot-brand{font-family:var(--disp);font-weight:700;font-size:1.1rem;letter-spacing:-.01em}
+.foot-links{display:flex;gap:22px;font-family:var(--mono);font-size:.7rem;
+  letter-spacing:.12em;text-transform:uppercase;color:var(--muted)}
+.foot-links a:hover{color:var(--red)}
+.foot-copy{margin-top:18px;font-family:var(--mono);font-size:.68rem;letter-spacing:.12em;
+  text-transform:uppercase;color:var(--muted);opacity:.75}

--- a/_sass/hero.scss
+++ b/_sass/hero.scss
@@ -1,12 +1,30 @@
-.hero{padding:96px 0 72px;position:relative;overflow:hidden}
-.hero-glow{position:absolute;top:-160px;right:-120px;width:520px;height:520px;border-radius:50%;
-  background:radial-gradient(circle,rgba(192,132,252,.16),transparent 62%);pointer-events:none}
+.hero{padding:0;position:relative;overflow:hidden;border-bottom:1px solid var(--line)}
+.hero-grid{display:grid;grid-template-columns:7fr 5fr;align-items:stretch;min-height:60vh}
+.hero-main{display:flex;flex-direction:column;justify-content:center;
+  padding:64px 40px 56px 0}
 .hero .kicker{margin-bottom:22px}
-.hero-h{font-family:var(--disp);font-weight:700;font-size:clamp(2.6rem,6vw,4.6rem);
-  line-height:1.02;letter-spacing:-.02em;margin:0 0 20px}
-.hero-h .accent{color:var(--accent)}
-.hero-sub{font-family:var(--serif);font-size:clamp(1.15rem,2.2vw,1.5rem);color:#CFCDC6;
-  max-width:36ch;margin:0 0 30px;line-height:1.45}
-.hero-btns{display:flex;gap:14px;flex-wrap:wrap;align-items:center}
+.hero-h{font-family:var(--disp);font-weight:600;font-size:clamp(2.6rem,6vw,5rem);
+  line-height:.98;letter-spacing:-.03em;margin:0 0 22px}
+.hero-h .accent{color:var(--red)}
+.hero-sub{font-family:var(--body);font-size:clamp(1.05rem,1.8vw,1.2rem);color:var(--muted);
+  max-width:42ch;margin:0 0 32px;line-height:1.5}
+.hero-btns{display:flex;gap:24px;flex-wrap:wrap;align-items:center}
 .socials{margin-left:6px;display:flex;gap:14px;color:var(--muted);font-family:var(--mono);font-size:.8rem}
-.socials a:hover{color:var(--accent)}
+.socials a:hover{color:var(--red)}
+
+/* Bauhaus composition in the right grid field, Riso-overprinted */
+.hero-fig{position:relative}
+.hero-fig span{position:absolute}
+.fig-c-y{width:min(58%,220px);aspect-ratio:1;border-radius:50%;background:var(--yellow);right:6%;top:14%}
+.fig-tri{right:2%;top:32%;width:0;height:0;
+  border-left:96px solid transparent;border-right:96px solid transparent;
+  border-bottom:170px solid var(--red);mix-blend-mode:var(--blend)}
+.fig-c-b{width:120px;height:120px;border-radius:50%;background:var(--blue);
+  right:44%;bottom:16%;mix-blend-mode:var(--blend)}
+
+@media(max-width:820px){
+  .hero-grid{grid-template-columns:1fr;min-height:0}
+  .hero-main{padding:56px 0 44px}
+  .hero-fig{min-height:240px}
+  .fig-c-y{top:24%}
+}

--- a/_sass/light.scss
+++ b/_sass/light.scss
@@ -1,11 +1,12 @@
+/* ============================================================
+   Light theme — the Riso "paper" surface
+   ============================================================ */
 [data-theme="light"]{
-  --bg:#FBF8F1; --bg2:#F1ECE0; --card:#FFFFFF; --line:rgba(0,0,0,.10);
-  --ink:#211E1A; --muted:#6B6A64; --accent:#7C3AED; --amber:#B45309;
+  --bg:#F4F1E9; --bg2:#ECE8DD; --card:#FBFAF5;
+  --line:rgba(23,20,16,.16); --line2:rgba(23,20,16,.30);
+  --ink:#171410; --muted:#7A7368;
+  --red:#F24333; --blue:#1961E0; --yellow:#FFC21A;
+  --blend:multiply;          /* true overprint on paper */
 }
-[data-theme="light"] .site-nav{background:color-mix(in srgb,var(--bg) 80%,transparent)}
-[data-theme="light"] .nav-cta{color:#fff!important}
-[data-theme="light"] .btn-primary{color:#fff}
-[data-theme="light"] .hero-sub{color:#3B3833}
-[data-theme="light"] .about blockquote{color:#2C2A25}
-[data-theme="light"] .hero-glow{background:radial-gradient(circle,rgba(124,58,237,.12),transparent 62%)}
-[data-theme="light"] .shot span{color:var(--ink)}
+[data-theme="light"] .site-nav{background:color-mix(in srgb,var(--bg) 82%,transparent)}
+[data-theme="light"] .btn-primary{color:var(--red)}

--- a/_sass/nav.scss
+++ b/_sass/nav.scss
@@ -1,24 +1,27 @@
 .site-nav{position:sticky;top:0;z-index:20;backdrop-filter:blur(10px);
-  background:color-mix(in srgb,var(--bg) 72%,transparent);border-bottom:1px solid var(--line)}
-.nav-in{display:flex;align-items:center;gap:28px;height:64px}
-.brand{display:inline-flex;align-items:center;gap:9px;font-family:var(--mono);color:var(--accent);font-size:.95rem;font-weight:500}
-.brand-logo{width:26px;height:26px;object-fit:contain;filter:invert(1)}
-[data-theme="light"] .brand-logo{filter:none}
-.nav-links{margin-left:auto;display:flex;gap:26px;align-items:center;
-  font-family:var(--disp);font-weight:500;font-size:.92rem}
+  background:color-mix(in srgb,var(--bg) 78%,transparent);border-bottom:1px solid var(--line)}
+.nav-in{display:flex;align-items:center;gap:28px;height:66px}
+.brand{display:inline-flex;align-items:center;gap:11px;font-family:var(--disp);
+  color:var(--ink);font-size:1rem;font-weight:700;letter-spacing:-.01em}
+.brand-logo{width:26px;height:26px;object-fit:contain}
+[data-theme="dark"] .brand-logo{filter:invert(1)}
+.nav-links{margin-left:auto;display:flex;gap:28px;align-items:center;
+  font-family:var(--mono);font-weight:500;font-size:.72rem;letter-spacing:.12em;text-transform:uppercase}
 .nav-links a{color:var(--muted);transition:color .15s}
 .nav-links a:hover{color:var(--ink)}
 .nav-links a.active{color:var(--ink)}
-.nav-links a.active:not(.nav-cta){box-shadow:inset 0 -2px 0 var(--accent)}
-.nav-cta{color:var(--bg)!important;background:var(--accent);padding:8px 16px;border-radius:999px}
-.theme-toggle{background:none;border:1px solid var(--line);color:var(--muted);
-  border-radius:999px;width:34px;height:34px;cursor:pointer;line-height:1}
+.nav-links a.active:not(.nav-cta){box-shadow:inset 0 -2px 0 var(--red)}
+.nav-cta{color:var(--muted)}
+.nav-cta:hover{color:var(--ink)}
+.theme-toggle{background:none;border:1px solid var(--line2);color:var(--muted);
+  width:34px;height:34px;cursor:pointer;line-height:1}
+.theme-toggle:hover{color:var(--ink);border-color:var(--ink)}
 .nav-toggle{display:none;margin-left:auto;background:none;border:0;cursor:pointer;
   flex-direction:column;gap:5px;padding:8px}
 .nav-toggle span{width:22px;height:2px;background:var(--ink);display:block}
 @media(max-width:720px){
   .nav-toggle{display:flex}
-  .nav-links{position:absolute;top:64px;left:0;right:0;background:var(--bg2);
+  .nav-links{position:absolute;top:66px;left:0;right:0;background:var(--bg2);
     flex-direction:column;gap:18px;padding:22px 24px;border-bottom:1px solid var(--line);
     margin-left:0;display:none}
   .nav-links.open{display:flex}

--- a/_sass/tokens.scss
+++ b/_sass/tokens.scss
@@ -1,7 +1,26 @@
+/* ============================================================
+   Swiss × Bauhaus × Riso design tokens
+   Swiss grid + type · Bauhaus primaries · Riso spot inks
+   Default (:root) = warm dark paper. [data-theme=light] = paper.
+   ============================================================ */
 :root{
-  --bg:#0E0F12; --bg2:#15171C; --card:#16181E; --line:rgba(255,255,255,.09);
-  --ink:#E9E7E1; --muted:#9BA0A8; --accent:#C084FC; --amber:#F5B841;
-  --disp:'Space Grotesk',sans-serif; --serif:'Newsreader',Georgia,serif;
-  --mono:'JetBrains Mono',monospace; --body:'Inter',sans-serif;
-  --wrap:1080px; --gutter:24px;
+  /* surfaces (dark) */
+  --bg:#14120E; --bg2:#1B1712; --card:#1D1914;
+  --line:rgba(244,241,233,.15); --line2:rgba(244,241,233,.30);
+  --ink:#F1EEE7; --muted:#9C948A;
+
+  /* riso spot inks */
+  --red:#F24333; --blue:#5B90F5; --yellow:#FFC21A;
+  --accent:var(--red); --amber:var(--yellow);
+  --blend:screen;            /* overprint mode for dark */
+
+  /* type */
+  --disp:'Libre Franklin',system-ui,sans-serif;  /* Swiss grotesque */
+  --alt:'Archivo',system-ui,sans-serif;
+  --mono:'JetBrains Mono',monospace;
+  --body:'Inter',system-ui,sans-serif;
+  --serif:'Newsreader',Georgia,serif;            /* prose */
+
+  /* grid */
+  --wrap:1120px; --gutter:32px; --gap:24px;
 }

--- a/_sass/utilities.scss
+++ b/_sass/utilities.scss
@@ -1,22 +1,36 @@
 .wrap{max-width:var(--wrap);margin:0 auto;padding:0 var(--gutter)}
-.mono{font-family:var(--mono);font-size:.72rem;letter-spacing:.08em;
+.mono{font-family:var(--mono);font-size:.72rem;letter-spacing:.16em;
   text-transform:uppercase;color:var(--muted)}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;
   overflow:hidden;clip:rect(0,0,0,0);border:0}
 
-.section{padding:64px 0;border-top:1px solid var(--line)}
-.sec-head{display:flex;align-items:baseline;justify-content:space-between;
-  margin-bottom:32px;gap:16px;flex-wrap:wrap}
-.sec-head h2{font-family:var(--disp);font-weight:600;font-size:1.7rem;margin:0;letter-spacing:-.01em}
-.sec-head a{font-family:var(--mono);font-size:.75rem;color:var(--muted)}
-.sec-head a:hover{color:var(--accent)}
+/* Swiss section */
+.section{padding-top:56px;padding-bottom:64px;border-top:1px solid var(--line)}
 
-.empty{border:1px dashed var(--line);border-radius:14px;padding:34px;
-  text-align:center;color:var(--muted)}
-.empty .mono{display:block;margin-bottom:8px;color:var(--amber)}
+/* Scroll-reveal (only active once JS adds .reveal to <html>) */
+.reveal .section{opacity:0;transform:translateY(16px);
+  transition:opacity .6s ease,transform .6s ease}
+.reveal .section.in{opacity:1;transform:none}
+@media (prefers-reduced-motion: reduce){
+  .reveal .section{opacity:1!important;transform:none!important}
+}
+.sec-head{display:flex;align-items:baseline;gap:18px;
+  margin-bottom:40px;padding-bottom:18px;border-bottom:1px solid var(--line)}
+.sec-head h2{font-family:var(--disp);font-weight:600;font-size:clamp(1.5rem,3vw,2rem);
+  margin:0;letter-spacing:-.02em}
+.sec-head a{margin-left:auto;font-family:var(--mono);font-size:.72rem;
+  letter-spacing:.12em;text-transform:uppercase;color:var(--ink)}
+.sec-head a:hover{color:var(--red)}
+
+.empty{border:1px solid var(--line);padding:34px;color:var(--muted)}
+.empty .mono{display:block;margin-bottom:8px;color:var(--red)}
 .empty p{margin:0;font-size:.92rem}
 
-.btn{font-family:var(--disp);font-weight:600;font-size:.95rem;padding:12px 22px;
-  border-radius:999px;display:inline-block}
-.btn-primary{background:var(--accent);color:var(--bg)}
-.btn-ghost{border:1px solid var(--line);color:var(--ink)}
+/* Underline buttons — Swiss, functional */
+.btn{font-family:var(--mono);font-weight:500;font-size:.78rem;text-transform:uppercase;
+  letter-spacing:.1em;padding-bottom:4px;display:inline-block;
+  border-bottom:2px solid var(--ink);transition:color .18s,border-color .18s}
+.btn-primary{color:var(--red);border-color:var(--red)}
+.btn-primary:hover{color:var(--muted);border-color:var(--muted)}
+.btn-ghost{color:var(--ink);border-color:var(--ink)}
+.btn-ghost:hover{color:var(--muted);border-color:var(--muted)}

--- a/_sass/writing.scss
+++ b/_sass/writing.scss
@@ -1,6 +1,8 @@
 .post-single{padding:64px 0;max-width:720px}
+.post-single > .mono{color:var(--red);letter-spacing:.14em}
 .prose img.avatar{width:132px;height:132px;border-radius:50%;object-fit:cover;border:1px solid var(--line);margin:0 0 22px}
-.post-title{font-family:var(--serif);font-weight:600;font-size:clamp(2rem,4vw,2.8rem);margin:.4rem 0 1.4rem}
+.post-title{font-family:var(--disp);font-weight:600;font-size:clamp(2rem,4vw,2.8rem);
+  margin:.6rem 0 1.4rem;padding-bottom:1.2rem;border-bottom:1px solid var(--line);letter-spacing:-.02em}
 .prose{font-family:var(--body);font-size:1.06rem;line-height:1.75}
 .prose h2{font-family:var(--disp);margin-top:2rem}
 .prose h3{font-family:var(--serif)}

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -11,4 +11,16 @@
     var open=navLinks.classList.toggle('open');
     navToggle.setAttribute('aria-expanded',open?'true':'false');
   });}
+
+  /* Subtle scroll-reveal for sections (reduced-motion safe) */
+  var reduce=matchMedia('(prefers-reduced-motion: reduce)').matches;
+  if(!reduce&&'IntersectionObserver'in window){
+    root.classList.add('reveal');
+    var io=new IntersectionObserver(function(entries){
+      entries.forEach(function(e){
+        if(e.isIntersecting){e.target.classList.add('in');io.unobserve(e.target);}
+      });
+    },{rootMargin:'0px 0px -8% 0px',threshold:.08});
+    document.querySelectorAll('.section').forEach(function(el){io.observe(el);});
+  }
 })();


### PR DESCRIPTION
- New design tokens: Libre Franklin/Archivo type, riso spot inks (red/blue/yellow), 12-col grid vars
- Light (paper) default with dark toggle; riso grain overlay + overprint blend
- Split-grid hero with Bauhaus composition; underline buttons
- Swiss numbered-free section heads, hairline rules, bordered card grids
- Bauhaus primary badges on projects, primary bullets on Now list
- Subtle scroll-reveal (reduced-motion safe); Swiss article masthead
- Restore logo mark; de-emphasize Contact CTA; trim name from footer