### PR TITLE
feat(ui): Bauhaus hero/icons refinement + search, back-to-top, 404, r…

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,8 +2,19 @@
 layout: default
 permalink: /404.html
 ---
-<section class="wrap section" style="text-align:center;padding:120px 0">
-  <p class="mono">// 404</p>
-  <h1 class="hero-h" style="font-size:2.4rem">Page not found</h1>
-  <p><a class="btn btn-primary" href="{{ '/' | relative_url }}">Go home</a></p>
+<section class="wrap section error404">
+  <svg class="bauhaus err-bauhaus" viewBox="0 0 340 380" aria-hidden="true">
+    <polygon class="y" points="150,28 254,236 46,236"/>
+    <circle class="b" cx="228" cy="132" r="96"/>
+    <rect class="r" x="150" y="176" width="126" height="126"/>
+    <circle class="ring" cx="86" cy="150" r="40"/>
+    <rect class="k" x="34" y="330" width="150" height="7"/>
+  </svg>
+  <p class="mono">// error 404</p>
+  <h1 class="err-code">404</h1>
+  <p class="err-msg">This page wandered off the grid.</p>
+  <div class="btns">
+    <a class="btn btn-primary" href="{{ '/' | relative_url }}">Go home</a>
+    <a class="btn btn-ghost" href="{{ '/writing/' | relative_url }}">Read the blog</a>
+  </div>
 </section>

--- a/_includes/bauhaus-icon.html
+++ b/_includes/bauhaus-icon.html
@@ -1,0 +1,33 @@
+{%- comment -%}
+================================================================
+  Bauhaus icon — DESIGN PATTERN (single source of truth)
+  Kandinsky colour/shape mapping: circle = blue (.b), triangle = yellow (.y), square = red (.r).
+  All icons share ONE canonical size per shape, in a 0 0 44 44 viewBox, so
+  every circle / triangle / square is identical across the whole site.
+
+  Canonical shapes:
+    • circle   — r 12
+    • square   — 22 × 22
+    • triangle — base 26, height 22
+
+  Two fixed slots (so overlap/overprint is consistent everywhere):
+    • slot L (lower-left,  centre 16,25)
+    • slot R (upper-right, centre 28,17)
+
+  Usage:
+    {% include bauhaus-icon.html l="triangle" r="circle" %}
+  where l / r ∈ circle | square | triangle
+================================================================
+{%- endcomment -%}
+{%- assign L = include.l -%}
+{%- assign R = include.r -%}
+<svg class="ic" viewBox="0 0 44 44" aria-hidden="true">
+{%- if L == "circle" %}<circle class="b" cx="16" cy="25" r="12"/>
+{%- elsif L == "square" %}<rect class="r" x="5" y="14" width="22" height="22"/>
+{%- elsif L == "triangle" %}<polygon class="y" points="16,11 29,33 3,33"/>
+{%- endif -%}
+{%- if R == "circle" %}<circle class="b" cx="28" cy="17" r="12"/>
+{%- elsif R == "square" %}<rect class="r" x="17" y="6" width="22" height="22"/>
+{%- elsif R == "triangle" %}<polygon class="y" points="28,3 41,25 15,25"/>
+{%- endif -%}
+</svg>

--- a/_includes/facets.html
+++ b/_includes/facets.html
@@ -1,8 +1,8 @@
 <section class="wrap section">
   <div class="sec-head"><h2>What I do</h2></div>
   <div class="facets">
-    <a class="facet" href="{{ '/projects/' | relative_url }}"><div class="ic" aria-hidden="true">📊</div><h3>Data Science</h3><p>Turning data into models, tools, and decisions across a broad range of problems.</p><span class="lk">Projects →</span></a>
-    <a class="facet" href="{{ '/making/' | relative_url }}"><div class="ic" aria-hidden="true">🔧</div><h3>Making</h3><p>Hands-on projects of all kinds, from hardware and tools to fermentation and small builds.</p><span class="lk">See making →</span></a>
-    <a class="facet" href="{{ '/writing/' | relative_url }}"><div class="ic" aria-hidden="true">✍️</div><h3>Writing</h3><p>Notes on what I'm learning about data, code, and the things I build.</p><span class="lk">Read →</span></a>
+    <a class="facet" href="{{ '/projects/' | relative_url }}">{% include bauhaus-icon.html l="triangle" r="circle" %}<h3>Data Science</h3><p>Turning data into models, tools, and decisions across a broad range of problems.</p><span class="lk">Projects →</span></a>
+    <a class="facet" href="{{ '/making/' | relative_url }}">{% include bauhaus-icon.html l="square" r="triangle" %}<h3>Making</h3><p>Hands-on projects of all kinds, from hardware and tools to fermentation and small builds.</p><span class="lk">See making →</span></a>
+    <a class="facet" href="{{ '/writing/' | relative_url }}">{% include bauhaus-icon.html l="circle" r="square" %}<h3>Writing</h3><p>Notes on what I'm learning about data, code, and the things I build.</p><span class="lk">Read →</span></a>
   </div>
 </section>

--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -10,9 +10,13 @@
       </div>
     </div>
     <div class="hero-fig" aria-hidden="true">
-      <span class="fig-c-y"></span>
-      <span class="fig-tri"></span>
-      <span class="fig-c-b"></span>
+      <svg class="bauhaus" viewBox="0 0 340 380">
+        <polygon class="y" points="150,28 254,236 46,236"/>
+        <circle class="b" cx="228" cy="132" r="96"/>
+        <rect class="r" x="150" y="176" width="126" height="126"/>
+        <circle class="ring" cx="86" cy="150" r="40"/>
+        <rect class="k" x="34" y="330" width="150" height="7"/>
+      </svg>
     </div>
   </div>
 </header>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -15,6 +15,7 @@
           <a href="{{ item.url | relative_url }}" class="{% if item.cta %}nav-cta{% endif %}{% if active %} active{% endif %}"{% if active %} aria-current="page"{% endif %}>{{ item.title }}</a>
         {% endunless %}
       {% endfor %}
+      <button id="search-toggle" class="icon-btn" type="button" aria-label="Search" title="Search ( / )"><span aria-hidden="true">⌕</span></button>
       {% include theme-toggle.html %}
     </div>
   </div>

--- a/_includes/search.html
+++ b/_includes/search.html
@@ -1,0 +1,12 @@
+<div id="search" class="search" hidden data-endpoint="{{ '/assets/search-data.json' | relative_url }}">
+  <div class="search-backdrop" data-search-close></div>
+  <div class="search-panel" role="dialog" aria-modal="true" aria-label="Search">
+    <div class="search-bar">
+      <span class="search-ic" aria-hidden="true">⌕</span>
+      <input id="search-input" type="search" placeholder="Search writing, projects, making…" autocomplete="off" aria-label="Search the site">
+      <button class="search-close" type="button" data-search-close aria-label="Close search">esc</button>
+    </div>
+    <ul id="search-results" class="search-results" role="listbox" aria-label="Search results"></ul>
+    <p class="search-empty" id="search-empty" hidden>No matches.</p>
+  </div>
+</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,6 +5,8 @@
   {% include nav.html %}
   <main id="main">{{ content }}</main>
   {% include footer.html %}
+  <button id="to-top" class="to-top" type="button" aria-label="Back to top" hidden>↑</button>
+  {% include search.html %}
   <script src="{{ '/assets/js/theme.js' | relative_url }}" defer></script>
 </body>
 </html>

--- a/_sass/cards.scss
+++ b/_sass/cards.scss
@@ -2,11 +2,15 @@
 .facets{display:grid;gap:0;grid-template-columns:1fr;border:1px solid var(--line2)}
 @media(min-width:800px){.facets{grid-template-columns:repeat(3,1fr)}}
 .facet{background:var(--card);border-bottom:1px solid var(--line2);padding:28px 24px;
-  transition:background .18s;display:block}
+  transition:background .18s ease,transform .2s ease,opacity .5s ease;display:block}
 @media(min-width:800px){.facet{border-bottom:0;border-right:1px solid var(--line2)}
   .facet:last-child{border-right:0}}
-.facet:hover{background:var(--bg2)}
-.facet .ic{font-size:1.4rem;margin-bottom:16px}
+.facet:hover{background:var(--bg2);transform:translateY(-4px)}
+.facet .ic{width:40px;height:40px;margin-bottom:16px;display:block;overflow:visible}
+.facet .ic .y{fill:var(--yellow);mix-blend-mode:var(--blend)}
+.facet .ic .b{fill:var(--blue);mix-blend-mode:var(--blend)}
+.facet .ic .r{fill:var(--red);mix-blend-mode:var(--blend)}
+.facet .ic .k{fill:none;stroke:var(--ink);stroke-width:2.5}
 .facet h3{font-family:var(--disp);font-weight:600;font-size:1.1rem;margin:0 0 8px;letter-spacing:-.01em}
 .facet p{color:var(--muted);font-size:.9rem;margin:0}
 .facet .lk{display:inline-block;margin-top:16px;font-family:var(--mono);font-size:.68rem;
@@ -15,7 +19,8 @@
 /* Writing list — hairline editorial rows */
 .posts{display:flex;flex-direction:column}
 .post{display:grid;grid-template-columns:96px 1fr;gap:24px;padding:22px 0;
-  border-top:1px solid var(--line);align-items:baseline;transition:padding-left .18s}
+  border-top:1px solid var(--line);align-items:baseline;
+  transition:padding-left .18s ease,transform .2s ease,opacity .5s ease}
 .post:first-child{border-top:0}
 .post:hover{padding-left:12px}
 .post:hover h3{color:var(--red)}
@@ -29,10 +34,10 @@
 .projects{display:grid;gap:0;grid-template-columns:1fr;border:1px solid var(--line2)}
 @media(min-width:800px){.projects{grid-template-columns:1fr 1fr}}
 .proj{background:var(--card);border-bottom:1px solid var(--line2);padding:26px 24px;
-  transition:background .18s;display:flex;flex-direction:column;min-height:200px}
+  transition:background .18s ease,transform .2s ease,opacity .5s ease;display:flex;flex-direction:column;min-height:200px}
 @media(min-width:800px){.proj{border-right:1px solid var(--line2)}
   .proj:nth-child(2n){border-right:0}}
-.proj:hover{background:var(--bg2)}
+.proj:hover{background:var(--bg2);transform:translateY(-4px)}
 .proj::before{content:"";width:26px;height:26px;margin-bottom:auto;display:block}
 .proj:nth-child(3n+1)::before{background:var(--red);border-radius:50%}
 .proj:nth-child(3n+2)::before{background:var(--yellow)}
@@ -50,8 +55,9 @@
 .gallery-index{grid-template-columns:repeat(2,1fr)}
 @media(min-width:800px){.gallery-index{grid-template-columns:repeat(3,1fr)}}
 .shot{aspect-ratio:1;border:1px solid var(--line2);display:flex;
-  align-items:flex-end;padding:12px;background:var(--card);transition:border-color .18s}
-.shot:hover{border-color:var(--ink)}
+  align-items:flex-end;padding:12px;background:var(--card);
+  transition:border-color .18s ease,transform .2s ease,opacity .5s ease}
+.shot:hover{border-color:var(--ink);transform:translateY(-4px)}
 .shot span{font-family:var(--mono);font-size:.66rem;letter-spacing:.06em;text-transform:uppercase;
   color:var(--ink);font-weight:500}
 

--- a/_sass/components.scss
+++ b/_sass/components.scss
@@ -1,0 +1,57 @@
+/* ============================================================
+   Components — search overlay, back-to-top, 404
+   ============================================================ */
+
+/* Icon button (nav search trigger) */
+.icon-btn{background:none;border:1px solid var(--line2);color:var(--muted);
+  width:34px;height:34px;cursor:pointer;line-height:1;font-size:1rem;
+  display:inline-flex;align-items:center;justify-content:center}
+.icon-btn:hover{color:var(--ink);border-color:var(--ink)}
+
+/* ---------- Search overlay ---------- */
+.search{position:fixed;inset:0;z-index:60;display:flex;justify-content:center;align-items:flex-start}
+.search[hidden]{display:none}
+.search-backdrop{position:absolute;inset:0;
+  background:color-mix(in srgb,var(--ink) 42%,transparent);backdrop-filter:blur(2px)}
+.search-panel{position:relative;margin-top:12vh;width:min(640px,92vw);
+  background:var(--card);border:2px solid var(--ink);box-shadow:8px 8px 0 var(--ink)}
+.search-bar{display:flex;align-items:center;gap:12px;padding:16px 18px;border-bottom:1px solid var(--line)}
+.search-ic{font-size:1.3rem;color:var(--muted);line-height:1}
+#search-input{flex:1;border:0;background:none;font-family:var(--disp);font-size:1.1rem;
+  color:var(--ink);outline:none}
+.search-close{font-family:var(--mono);font-size:.62rem;text-transform:uppercase;letter-spacing:.12em;
+  border:1px solid var(--line2);background:none;color:var(--muted);padding:5px 8px;cursor:pointer}
+.search-close:hover{color:var(--ink);border-color:var(--ink)}
+.search-results{list-style:none;margin:0;padding:6px;max-height:56vh;overflow:auto}
+.search-item a{display:grid;grid-template-columns:auto 1fr;gap:2px 14px;
+  padding:12px 14px;text-decoration:none;color:var(--ink);border-bottom:1px solid var(--line)}
+.search-item:last-child a{border-bottom:0}
+.search-item a:hover,.search-item a:focus{background:var(--bg2);outline:none}
+.s-type{grid-row:1/3;align-self:start;margin-top:2px;font-family:var(--mono);font-size:.58rem;
+  text-transform:uppercase;letter-spacing:.1em;color:var(--red);
+  border:1px solid var(--line2);padding:3px 6px;height:max-content}
+.s-title{font-family:var(--disp);font-weight:600;font-size:1rem;letter-spacing:-.01em}
+.s-sum{color:var(--muted);font-size:.82rem}
+.search-empty{margin:0;padding:22px 18px;color:var(--muted);
+  font-family:var(--mono);font-size:.78rem;letter-spacing:.06em}
+
+/* ---------- Back-to-top ---------- */
+.to-top{position:fixed;right:24px;bottom:24px;z-index:40;width:46px;height:46px;
+  border:2px solid var(--ink);background:var(--yellow);color:var(--ink);cursor:pointer;
+  font-size:1.15rem;line-height:1;box-shadow:4px 4px 0 var(--ink);
+  transition:transform .14s ease,box-shadow .14s ease}
+.to-top[hidden]{display:none}
+.to-top:hover{transform:translate(-2px,-2px);box-shadow:6px 6px 0 var(--ink)}
+
+/* ---------- 404 ---------- */
+.error404{text-align:center;padding:72px 0 96px;display:flex;flex-direction:column;align-items:center;gap:14px}
+.err-bauhaus{width:min(66%,280px);height:auto;margin-bottom:6px}
+.err-bauhaus .y{fill:var(--yellow);mix-blend-mode:var(--blend)}
+.err-bauhaus .b{fill:var(--blue);mix-blend-mode:var(--blend)}
+.err-bauhaus .r{fill:var(--red);mix-blend-mode:var(--blend)}
+.err-bauhaus .ring{fill:none;stroke:var(--ink);stroke-width:3;mix-blend-mode:var(--blend)}
+.err-bauhaus .k{fill:var(--ink)}
+.err-code{font-family:var(--disp);font-weight:600;font-size:clamp(4rem,16vw,9rem);
+  line-height:.9;letter-spacing:-.04em;margin:0}
+.err-msg{color:var(--muted);font-family:var(--disp);font-size:1.2rem;margin:0}
+.error404 .btns{display:flex;gap:24px;flex-wrap:wrap;justify-content:center;margin-top:8px}

--- a/_sass/hero.scss
+++ b/_sass/hero.scss
@@ -12,19 +12,18 @@
 .socials{margin-left:6px;display:flex;gap:14px;color:var(--muted);font-family:var(--mono);font-size:.8rem}
 .socials a:hover{color:var(--red)}
 
-/* Bauhaus composition in the right grid field, Riso-overprinted */
-.hero-fig{position:relative}
-.hero-fig span{position:absolute}
-.fig-c-y{width:min(58%,220px);aspect-ratio:1;border-radius:50%;background:var(--yellow);right:6%;top:14%}
-.fig-tri{right:2%;top:32%;width:0;height:0;
-  border-left:96px solid transparent;border-right:96px solid transparent;
-  border-bottom:170px solid var(--red);mix-blend-mode:var(--blend)}
-.fig-c-b{width:120px;height:120px;border-radius:50%;background:var(--blue);
-  right:44%;bottom:16%;mix-blend-mode:var(--blend)}
+/* Bauhaus composition (blue circle, yellow triangle, red square), Riso-overprinted */
+.hero-fig{margin:0;position:relative;display:flex;flex-direction:column;
+  justify-content:center;align-items:flex-start;padding:48px 0}
+.hero-fig .bauhaus{width:min(100%,380px);height:auto;overflow:visible}
+.bauhaus .y{fill:var(--yellow);mix-blend-mode:var(--blend)}
+.bauhaus .b{fill:var(--blue);mix-blend-mode:var(--blend)}
+.bauhaus .r{fill:var(--red);mix-blend-mode:var(--blend)}
+.bauhaus .ring{fill:none;stroke:var(--ink);stroke-width:3;mix-blend-mode:var(--blend)}
+.bauhaus .k{fill:var(--ink)}
 
 @media(max-width:820px){
   .hero-grid{grid-template-columns:1fr;min-height:0}
   .hero-main{padding:56px 0 44px}
-  .hero-fig{min-height:240px}
-  .fig-c-y{top:24%}
+  .hero-fig{padding:8px 0 40px;align-items:center}
 }

--- a/_sass/utilities.scss
+++ b/_sass/utilities.scss
@@ -11,8 +11,17 @@
 .reveal .section{opacity:0;transform:translateY(16px);
   transition:opacity .6s ease,transform .6s ease}
 .reveal .section.in{opacity:1;transform:none}
+/* staggered children */
+.reveal .facet,.reveal .proj,.reveal .post,.reveal .shot{opacity:0;transform:translateY(14px)}
+.reveal .section.in .facet,.reveal .section.in .proj,
+.reveal .section.in .post,.reveal .section.in .shot{opacity:1;transform:none}
+.reveal .section.in :is(.facet,.proj,.post,.shot):nth-child(2){transition-delay:.07s}
+.reveal .section.in :is(.facet,.proj,.post,.shot):nth-child(3){transition-delay:.14s}
+.reveal .section.in :is(.facet,.proj,.post,.shot):nth-child(4){transition-delay:.21s}
+.reveal .section.in :is(.facet,.proj,.post,.shot):nth-child(5){transition-delay:.28s}
 @media (prefers-reduced-motion: reduce){
-  .reveal .section{opacity:1!important;transform:none!important}
+  .reveal .section,
+  .reveal .facet,.reveal .proj,.reveal .post,.reveal .shot{opacity:1!important;transform:none!important}
 }
 .sec-head{display:flex;align-items:baseline;gap:18px;
   margin-bottom:40px;padding-bottom:18px;border-bottom:1px solid var(--line)}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -9,4 +9,5 @@
 @import "writing";
 @import "timeline";
 @import "footer";
+@import "components";
 @import "light";

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -23,4 +23,76 @@
     },{rootMargin:'0px 0px -8% 0px',threshold:.08});
     document.querySelectorAll('.section').forEach(function(el){io.observe(el);});
   }
+
+  /* Back-to-top */
+  var toTop=document.getElementById('to-top');
+  if(toTop){
+    var onScroll=function(){toTop.hidden=window.scrollY<=600;};
+    onScroll();
+    window.addEventListener('scroll',onScroll,{passive:true});
+    toTop.addEventListener('click',function(){
+      window.scrollTo({top:0,behavior:reduce?'auto':'smooth'});
+    });
+  }
+
+  /* Search overlay (lightweight index + `/` shortcut) */
+  var searchEl=document.getElementById('search');
+  var searchToggle=document.getElementById('search-toggle');
+  if(searchEl){
+    var input=document.getElementById('search-input');
+    var results=document.getElementById('search-results');
+    var empty=document.getElementById('search-empty');
+    var index=null,loading=false;
+    var esc=function(s){return String(s||'').replace(/[&<>"]/g,function(c){
+      return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c];});};
+    var load=function(){
+      if(index||loading)return;
+      loading=true;
+      fetch(searchEl.getAttribute('data-endpoint'))
+        .then(function(r){return r.json();})
+        .then(function(d){index=d;})
+        .catch(function(){index=[];});
+    };
+    var render=function(items){
+      results.innerHTML='';
+      if(empty)empty.hidden=!(input.value.trim()&&items.length===0);
+      items.forEach(function(it){
+        var li=document.createElement('li');
+        li.className='search-item';
+        li.innerHTML='<a href="'+esc(it.url)+'"><span class="s-type">'+esc(it.type)+
+          '</span><span class="s-title">'+esc(it.title)+
+          '</span><span class="s-sum">'+esc(it.summary)+'</span></a>';
+        results.appendChild(li);
+      });
+    };
+    var run=function(){
+      var q=input.value.trim().toLowerCase();
+      if(!q||!index){render([]);return;}
+      render(index.map(function(it){
+        var t=(it.title||'').toLowerCase(),s=(it.summary||'').toLowerCase(),sc=0;
+        if(t.indexOf(q)>-1)sc+=2; if(s.indexOf(q)>-1)sc+=1;
+        return {it:it,sc:sc};
+      }).filter(function(x){return x.sc>0;})
+        .sort(function(a,b){return b.sc-a.sc;})
+        .slice(0,8).map(function(x){return x.it;}));
+    };
+    var open=function(){
+      searchEl.hidden=false;root.style.overflow='hidden';load();
+      setTimeout(function(){input.focus();},20);
+    };
+    var close=function(){
+      searchEl.hidden=true;root.style.overflow='';input.value='';render([]);
+    };
+    if(searchToggle)searchToggle.addEventListener('click',open);
+    input.addEventListener('input',run);
+    searchEl.addEventListener('click',function(e){
+      if(e.target.hasAttribute('data-search-close'))close();
+    });
+    document.addEventListener('keydown',function(e){
+      var tag=(e.target&&e.target.tagName||'').toLowerCase();
+      if(e.key==='/'&&searchEl.hidden&&tag!=='input'&&tag!=='textarea'&&tag!=='select'){
+        e.preventDefault();open();
+      }else if(e.key==='Escape'&&!searchEl.hidden){close();}
+    });
+  }
 })();

--- a/assets/search-data.json
+++ b/assets/search-data.json
@@ -1,0 +1,20 @@
+---
+layout: null
+---
+{% assign sep = "" -%}
+[
+{% for p in site.posts -%}
+{{ sep }}{"title":{{ p.title | jsonify }},"url":{{ p.url | relative_url | jsonify }},"type":"Writing","summary":{{ p.excerpt | strip_html | strip_newlines | truncate: 140 | jsonify }}}
+{%- assign sep = "," -%}
+{% endfor -%}
+{% for pr in site.projects -%}
+{{ sep }}{"title":{{ pr.title | jsonify }},"url":{{ pr.url | relative_url | jsonify }},"type":"Project","summary":{{ pr.summary | default: "" | strip_html | strip_newlines | truncate: 140 | jsonify }}}
+{%- assign sep = "," -%}
+{% endfor -%}
+{% for m in site.making -%}
+{{ sep }}{"title":{{ m.title | jsonify }},"url":{{ m.url | relative_url | jsonify }},"type":"Making","summary":{{ m.summary | default: m.excerpt | default: "" | strip_html | strip_newlines | truncate: 140 | jsonify }}}
+{%- assign sep = "," -%}
+{% endfor -%}
+{{ sep }}{"title":"About","url":{{ "/about/" | relative_url | jsonify }},"type":"Page","summary":"About Akhilesh Koul — data scientist, maker, runner."}
+,{"title":"Contact","url":{{ "/contact/" | relative_url | jsonify }},"type":"Page","summary":"Get in touch."}
+]


### PR DESCRIPTION
…eveals

- Replace hero shapes with a Kandinsky-mapped SVG composition (blue circle, yellow triangle, red square) with Riso overprint; no attribution caption
- Add reusable bauhaus-icon.html pattern (canonical shape sizes, single source of truth) and use it for the What-I-do facet icons
- Wire up client-side search: generated assets/search-data.json index, nav button + '/' shortcut, Swiss overlay with Esc/backdrop close
- Add back-to-top control on long pages (reduced-motion safe)
- Restyle 404 with a full Bauhaus composition
- Staggered card reveals + subtle hover lift on facets/projects/posts/tiles